### PR TITLE
[RFR] Add an event_handler script for restarting services

### DIFF
--- a/eventhandlers/restart-service.py
+++ b/eventhandlers/restart-service.py
@@ -54,12 +54,12 @@ def main():
         default=3
     )
     parser.add_argument(
-        "-i",
-        "--inventory",
-        dest="inventory",
-        help="Location of the ansible inventory",
+        "-d",
+        "--directory",
+        dest="directory",
+        help="Directory from which to run the command, usually where ansible config files reside.",
         type=str,
-        default="/etc/shinken/ansible/inventory",
+        default="/etc/shinken/ansible"
     )
     args = parser.parse_args()
 
@@ -77,14 +77,12 @@ def main():
         command = [
             "ansible",
             args.hostname,
-            "-i",
-            args.inventory,
             "-m",
             "service",
             "-a",
-            "'name={} state=restarted'".format(args.service)
+            "name={} state=restarted".format(args.service)
         ]
-        output = subprocess.check_output(command, universal_newlines=True)
+        output = subprocess.check_output(command, universal_newlines=True, cwd=args.directory)
         print(output)
 
 

--- a/eventhandlers/restart-service.py
+++ b/eventhandlers/restart-service.py
@@ -63,16 +63,13 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.state != "CRITICAL":
-        # do nothing on non-critical states
-        return
-    elif args.type != "HARD":
-        # do nothing on non-hard critical states
-        return
-    elif args.attempt < args.max_attempts:
-        # do nothing if we are not at the max attempt number
-        return
-    else:
+    # we want to restart the service if it is in a critical SOFT state and has been checked
+    #   the max number of times, i.e. right before it notifies for human intervention OR
+    #   if the service somehow entered a HARD state
+    if (
+        (args.state == "CRITICAL" and args.type == "SOFT" and args.attempt >= args.max_attempts) or
+        (args.state == "CRITICAL" and args.type == "HARD")
+    ):
         # call ansible script to restart the service
         command = [
             "ansible",
@@ -84,6 +81,9 @@ def main():
         ]
         output = subprocess.check_output(command, universal_newlines=True, cwd=args.directory)
         print(output)
+    else:
+        # do nothing otherwise
+        return
 
 
 if __name__ == "__main__":

--- a/eventhandlers/restart-service.py
+++ b/eventhandlers/restart-service.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+"""
+Event handler to restart a service via ansible, requires ansible to be installed on the shinken
+server.
+"""
+
+import argparse
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-H",
+        "--hostname",
+        dest="hostname",
+        help="Hostname of Client",
+        type=str,
+    )
+    parser.add_argument(
+        "-S",
+        "--service",
+        dest="service",
+        help="Service desired for restart",
+        type=str,
+    )
+    parser.add_argument(
+        "-s",
+        "--state",
+        dest="state",
+        help="State of the check (e.g. 'OK', 'WARNING', 'CRITICAL')",
+        type=str,
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        dest="type",
+        help="Type of the state ('HARD' or 'SOFT')",
+        type=str,
+    )
+    parser.add_argument(
+        "-a",
+        "--attempt",
+        dest="attempt",
+        help="Attempt number on the service check",
+        type=int
+    )
+    parser.add_argument(
+        "-m",
+        "--max-attempts",
+        dest="max_attempts",
+        help="Number of max attempts allowed on the service check",
+        type=int,
+        default=3
+    )
+    parser.add_argument(
+        "-i",
+        "--inventory",
+        dest="inventory",
+        help="Location of the ansible inventory",
+        type=str,
+        default="/etc/shinken/ansible/inventory",
+    )
+    args = parser.parse_args()
+
+    if args.state != "CRITICAL":
+        # do nothing on non-critical states
+        return
+    elif args.type != "HARD":
+        # do nothing on non-hard critical states
+        return
+    elif args.attempt < args.max_attempts:
+        # do nothing if we are not at the max attempt number
+        return
+    else:
+        # call ansible script to restart the service
+        command = [
+            "ansible",
+            args.hostname,
+            "-i",
+            args.inventory,
+            "-m",
+            "service",
+            "-a",
+            "'name={} state=restarted'".format(args.service)
+        ]
+        output = subprocess.check_output(command, universal_newlines=True)
+        print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adding a script that will allow for us to use the `event_handler` feature of shinken to restart the `ovirt-engine` service when locked disk count is too high. This makes use of `ansible` to restart the service. 

A future PR will introduce the event_handler to https://github.com/kedark3/rhev-wrapanapi-pack/