### PR TITLE
[RFR] fixed the use of default values

### DIFF
--- a/check_rhv_main.py
+++ b/check_rhv_main.py
@@ -53,7 +53,6 @@ def main():
         dest="warning",
         help="Warning value. Could be fraction or whole number.",
         type=float,
-        default=0.75
     )
     parser.add_argument(
         "-c",
@@ -61,11 +60,16 @@ def main():
         dest="critical",
         help="Critical value. Could be fraction or whole number.",
         type=float,
-        default=0.9
     )
     args = parser.parse_args()
-    if float(args.warning) > float(args.critical):
+    if args.warning is not None and args.critical is not None and \
+            float(args.warning) > float(args.critical):
         print("Error: warning value can not be greater than critical value")
+        sys.exit(3)
+    elif (args.warning is None and args.critical is not None) or \
+            (args.warning is not None and args.critical is None):
+        print("Error: please provide both warning and critical values or use default values."
+              "You provided only {}".format("warning" if args.warning is not None else "critical"))
         sys.exit(3)
 
     # connect to the system
@@ -75,8 +79,13 @@ def main():
     if not measure_func:
         print("Error: measurement {} not understood".format(args.measurement))
         sys.exit(3)
+
     # run the measurement function
-    measure_func(system, warn=args.warning, crit=args.critical)
+    # if warning and critical values are not set, we need to use the default and not pass them
+    if args.warning is None and args.critical is None:
+        measure_func(system)
+    else:
+        measure_func(system, warn=args.warning, crit=args.critical)
 
 
 if __name__ == "__main__":

--- a/rhv_checks.py
+++ b/rhv_checks.py
@@ -19,12 +19,12 @@ def check_vm_count(system, warn=20, crit=30, **kwargs):
     if vm_count < warn:
         print("Ok: VM count is less than {}. VM Count = {}".format(warn, vm_count))
         sys.exit(0)
-    elif vm_count > warn and vm_count < crit:
+    elif warn < vm_count < crit:
         print("Warning: VM count is greater than {} & less than {}. VM Count = {}"
             .format(warn, crit, vm_count))
         sys.exit(1)
     elif vm_count > crit:
-        print("Critical: VM count is greate than crit. VM Count = {}".format(crit, vm_count))
+        print("Critical: VM count is greater than {}. VM Count = {}".format(crit, vm_count))
         sys.exit(2)
     else:
         print("Unknown: VM count is unknown")
@@ -217,8 +217,8 @@ def check_storage_domain_attached_status(system, **kwargs):
         attached_sds_service = dc_service.storage_domains_service()
         for sd in all_sd:
             if sd.type == types.StorageDomainType.IMAGE:
-               # Skipping sd as it is of type IMAGE
-               continue
+                # Skipping sd as it is of type IMAGE
+                continue
             attached_sds_service_sd_id = attached_sds_service.storage_domain_service(sd.id)
             status = attached_sds_service_sd_id.get().status
             if status == types.StorageDomainStatus.ACTIVE:
@@ -229,11 +229,12 @@ def check_storage_domain_attached_status(system, **kwargs):
 
     if critical:
         print("Critical: the following Storage Domain(s) definitely have an issue: {}\n "
-            "Status of all Storage Domain(s) are: {}".format(critical, all))
+              "Status of all Storage Domain(s) are: {}".format(critical, all))
         sys.exit(2)
     else:
         print("Ok: all Storage Domain(s) are Attached to Data Center(s): {}".format(okay))
         sys.exit(0)
+
 
 CHECKS = {
     "vm_count": check_vm_count,


### PR DESCRIPTION
Parser shouldn't contain default values as different functions have different default values specified in them as arguments.

Now it's possible to just run the check without specifying the values and it will pick up the correct ones from the function.

Also, some minor formatting changes (fixed lint errors that were highlighted in my IDE). 