### PR TITLE
[RFR] Add in a local logger so that commands can be tested locally

### DIFF
--- a/check_rhv_main.py
+++ b/check_rhv_main.py
@@ -9,7 +9,7 @@ import sys
 
 from argparse import RawTextHelpFormatter
 from rhv_checks import CHECKS
-from rhv_logconf import logger
+from rhv_logconf import get_logger
 from wrapanapi.systems.rhevm import RHEVMSystem
 
 
@@ -61,7 +61,18 @@ def main():
         help="Critical value. Could be fraction or whole number.",
         type=float,
     )
+    parser.add_argument(
+        "-l",
+        "--local",
+        dest="local",
+        help="Use this field when testing locally",
+        action="store_true",
+        default=False
+    )
     args = parser.parse_args()
+    # set logger
+    logger = get_logger(args.local)
+
     if args.warning is not None and args.critical is not None and \
             float(args.warning) > float(args.critical):
         logger.error("Error: warning value can not be greater than critical value")
@@ -87,9 +98,9 @@ def main():
     try:
         logger.info("Calling check %s", measure_func.__name__)
         if args.warning is None and args.critical is None:
-            measure_func(system)
+            measure_func(system, logger=logger)
         else:
-            measure_func(system, warn=args.warning, crit=args.critical)
+            measure_func(system, warn=args.warning, crit=args.critical, logger=logger)
     except Exception as e:
         logger.error(
             "Exception occurred during execution of %s",

--- a/rhv_checks.py
+++ b/rhv_checks.py
@@ -8,11 +8,11 @@ from __future__ import division
 import sys
 
 from ovirtsdk4 import types
-from rhv_logconf import logger
 
 
 def check_vm_count(system, warn=20, crit=30, **kwargs):
     """ Check overall host status. """
+    logger = kwargs["logger"]
     warn = int(warn)
     crit = int(crit)
     vm_count = len(system.list_vms())
@@ -42,6 +42,7 @@ def check_vm_count(system, warn=20, crit=30, **kwargs):
 
 def check_storage_domain_status(system, **kwargs):
     """ Check the usage of all the datastores on the host. """
+    logger = kwargs["logger"]
     okay, warning, critical, unknown, all = [], [], [], [], []
     storage_domains = system.api.system_service().storage_domains_service().list()
 
@@ -84,6 +85,7 @@ def check_storage_domain_status(system, **kwargs):
 
 def check_storage_domain_usage(system, warn=0.75, crit=0.9, **kwargs):
     """ Check the usage of all the datastores on the host. """
+    logger = kwargs["logger"]
     warn = float(warn)
     crit = float(crit)
     okay, warning, critical, unknown, all_sd = [], [], [], [], []
@@ -135,6 +137,7 @@ def check_storage_domain_usage(system, warn=0.75, crit=0.9, **kwargs):
 
 def check_locked_disks(system, warn=5, crit=10, **kwargs):
     """Check the count of locked disks."""
+    logger = kwargs["logger"]
     warn = int(warn)
     crit = int(crit)
     # following function call is not available in wrapanapi yet, need to merge PR#373
@@ -170,6 +173,7 @@ def check_locked_disks(system, warn=5, crit=10, **kwargs):
 
 def check_hosts_status(system, **kwargs):
     """ Check the status of all the hosts."""
+    logger = kwargs["logger"]
     okay, warning, critical, unknown, all = [], [], [], [], []
     hosts = system.api.system_service().hosts_service().list()
 
@@ -216,6 +220,7 @@ def check_hosts_status(system, **kwargs):
 
 def check_datacenters_status(system, **kwargs):
     """ Check the status of all the hosts."""
+    logger = kwargs["logger"]
     okay, warning, critical, unknown, all = [], [], [], [], []
     datacenters = system.api.system_service().data_centers_service().list()
 
@@ -260,6 +265,7 @@ def check_datacenters_status(system, **kwargs):
 
 def check_storage_domain_attached_status(system, **kwargs):
     """ Check the usage of all the datastores on the host. """
+    logger = kwargs["logger"]
     okay, critical, all = [], [], []
     storage_domains_service = system.api.system_service().storage_domains_service()
     all_sd = storage_domains_service.list()
@@ -294,7 +300,8 @@ def check_storage_domain_attached_status(system, **kwargs):
         sys.exit(0)
 
 
-def check_vms_distributed_hosts(system, warn=5, crit=10):
+def check_vms_distributed_hosts(system, warn=5, crit=10, **kwargs):
+    logger = kwargs["logger"]
     warn = int(warn)
     crit = int(crit)
     # get all the hosts

--- a/rhv_logconf/__init__.py
+++ b/rhv_logconf/__init__.py
@@ -1,7 +1,12 @@
 import logging
+import os
 
 from logging.config import fileConfig
 
 # setup logger
-fileConfig("/var/lib/shinken/libexec/rhv_logconf/logging_config.ini")
-logger = logging.getLogger()
+def get_logger(local):
+    if local:
+        fileConfig(os.getcwd() + "/rhv_logconf/local_config.ini")
+    else:
+        fileConfig("/var/lib/shinken/libexec/rhv_logconf/logging_config.ini")
+    return logging.getLogger()

--- a/rhv_logconf/local_config.ini
+++ b/rhv_logconf/local_config.ini
@@ -1,0 +1,27 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=fileHandler, stream_handler
+
+[formatters]
+keys=formatter
+
+[logger_root]
+level=DEBUG
+handlers=fileHandler
+
+[handler_stream_handler]
+class=StreamHandler
+level=DEBUG
+formatter=formatter
+args=(sys.stderr,)
+
+[handler_fileHandler]
+class=FileHandler
+level=DEBUG
+formatter=formatter
+args=("rhv-checks-" + time.strftime("%Y-%m-%d") + ".log", "a")
+
+[formatter_formatter]
+format=[%(asctime)s %(filename)-17s %(levelname)-7s] %(message)s


### PR DESCRIPTION
Adding a local logger so that commands can be tested locally. This can be used by passing the `--local` or `-l` parameter to the command. 